### PR TITLE
Add Response as member of ApiFactory.

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,4 +193,6 @@ class ApiFactory {
 	}
 }
 
+ApiFactory.Response = Resp;
+
 module.exports = ApiFactory;


### PR DESCRIPTION
This change adds the `Response`  class as member of `ApiFactory`.

This is needed by the `index.js` file generated by the `init` function:

```javascript
api.get('/livecheck', () => {
  return new Api.Response({
    "field": "hello world"
  }, 200);
});
```