### PR TITLE
Support proxy path with prefixes 

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ class ApiFactory {
 				}
 			} else {
 				// modify path to strip out potential stage in path 
-				event.path = event.resource.replace(proxyPath,'/'+ event.pathParameters.proxy)
+				event.path = `${event.resource.slice(0, -8)}${event.pathParameters.proxy}`;
 				// if it is a proxy path then then look up the proxied value.
 				let map = mapExapander.getMapValue(apiFactory.ProxyRoutes[event.httpMethod], event.path);
 				if (map) {
@@ -159,7 +159,7 @@ class ApiFactory {
 				throw new Error('Authorizer Undefined');
 			}
 			if (event.pathParameters && event.pathParameters.proxy) {
-				event.path = event.resource.replace('/{proxy+}', `/${event.pathParameters.proxy}`);
+				event.path = `${event.resource.slice(0, -8)}${event.pathParameters.proxy}`;
 			}
 			try {
 				let policy = await apiFactory.Authorizer(event);

--- a/index.js
+++ b/index.js
@@ -88,18 +88,19 @@ class ApiFactory {
 
 			let proxyPath = '/{proxy+}';
 			// default to defined path when proxy is not specified.
-			if (!event.resource.includes(proxyPath)) {
+			if (event.resource.lastIndexOf(proxyPath) === -1) {
 				if (mainEventHandler && mainEventHandler[event.resource]) {
 					definedRoute = mainEventHandler[event.resource];
 				} else if (anyEventHandler && anyEventHandler[event.resource]) {
 					definedRoute = anyEventHandler[event.resource];
 				}
 			} else {
+				// modify path to strip out potential stage in path 
+				event.path = event.resource.replace(proxyPath,'/'+ event.pathParameters.proxy)
 				// if it is a proxy path then then look up the proxied value.
 				let map = mapExapander.getMapValue(apiFactory.ProxyRoutes[event.httpMethod], event.path);
 				if (map) {
 					definedRoute = map.value;
-					event.path = event.pathParameters.proxy;
 					if (event.path[0] !== '/') { event.path = `/${event.path}`; }
 					event.pathParameters = map.tokens;
 				}

--- a/index.js
+++ b/index.js
@@ -100,8 +100,7 @@ class ApiFactory {
 				// if it is a proxy path then then look up the proxied value.
 				let map = mapExapander.getMapValue(apiFactory.ProxyRoutes[event.httpMethod], event.path);
 				if (map) {
-					definedRoute = map.value;
-					if (event.path[0] !== '/') { event.path = `/${event.path}`; }
+					definedRoute = map.value;	
 					event.pathParameters = map.tokens;
 				}
 			}
@@ -160,9 +159,7 @@ class ApiFactory {
 				throw new Error('Authorizer Undefined');
 			}
 			if (event.pathParameters && event.pathParameters.proxy) {
-				let newPath = event.pathParameters.proxy;
-				if (newPath[0] !== '/') { newPath = `/${newPath}`; }
-				event.path = newPath;
+				event.path = event.resource.replace('/{proxy+}', `/${event.pathParameters.proxy}`);
 			}
 			try {
 				let policy = await apiFactory.Authorizer(event);

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ class ApiFactory {
 
 			let proxyPath = '/{proxy+}';
 			// default to defined path when proxy is not specified.
-			if (event.resource !== proxyPath) {
+			if (!event.resource.includes(proxyPath)) {
 				if (mainEventHandler && mainEventHandler[event.resource]) {
 					definedRoute = mainEventHandler[event.resource];
 				} else if (anyEventHandler && anyEventHandler[event.resource]) {
@@ -96,7 +96,7 @@ class ApiFactory {
 				}
 			} else {
 				// if it is a proxy path then then look up the proxied value.
-				let map = mapExapander.getMapValue(apiFactory.ProxyRoutes[event.httpMethod], event.pathParameters.proxy);
+				let map = mapExapander.getMapValue(apiFactory.ProxyRoutes[event.httpMethod], event.path);
 				if (map) {
 					definedRoute = map.value;
 					event.path = event.pathParameters.proxy;

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,5 +1,6 @@
 require('error-object-polyfill');
-const { describe, it, beforeEach, afterEach } = require('mocha');
+const mocha = require('mocha');
+//{ describe, it, beforeEach, afterEach }
 const chai = require('chai');
 const { assert } = require('chai');
 const sinon = require('sinon');
@@ -480,6 +481,36 @@ describe('index.js', () => {
 				methodArn: 'methodArn'
 			});
 			assert.deepEqual(output, true, 'Output data does not match expected.');
+		});
+		it('check proxy path with prefix resolves correctly', async () => {
+			let api = new Api(null, () => {});
+			api.get('/v1/resource',event => {
+				return true; 
+			})
+			let output = await api.handler({
+				httpMethod: 'GET',
+				resource: '/v1/{proxy+}',
+				pathParameters: {
+					proxy: 'resource'
+				},
+				path: '/test-stage/v1/resource'
+			});
+			assert.deepEqual(output.body, 'true', 'Output data does not match expected.');
+		});
+		it('check proxy path without prefix resolves correctly', async () => {
+			let api = new Api(null, () => {});
+			api.get('/resource',event => {
+				return true; 
+			})
+			let output = await api.handler({
+				httpMethod: 'GET',
+				resource: '/{proxy+}',
+				pathParameters: {
+					proxy: 'resource'
+				},
+				path: '/test-stage/v1/resource'
+			});
+			assert.deepEqual(output.body, 'true', 'Output data does not match expected.');
 		});
 	});
 });

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,6 +1,5 @@
 require('error-object-polyfill');
-const mocha = require('mocha');
-//{ describe, it, beforeEach, afterEach }
+const { describe, it, beforeEach, afterEach } = require('mocha');
 const chai = require('chai');
 const { assert } = require('chai');
 const sinon = require('sinon');

--- a/tests/mapExpander.js
+++ b/tests/mapExpander.js
@@ -1,6 +1,7 @@
 require('error-object-polyfill');
-const { describe, it } = require('mocha');
-const { expect } = require('chai');
+const describe = require('mocha').describe
+const it = require('mocha').it
+const expect = require('chai').expect
 
 const MapExpander = require('../src/mapExpander');
 
@@ -342,6 +343,25 @@ describe('mapExpander.js', () => {
 						token2: 'resourceId'
 					}
 				}
+			},
+			{
+				name: 'path with stage should return null',
+				path: 'test/resource/resourceId/subresource1',
+				inputMap : {
+					resource :{
+						'*' : {
+							subresource1: {
+								_tokens: ['token1'],
+								_value: 'bad-value'
+							},
+							subresource2: {
+								_tokens: ['token2'],
+								_value: expectedValue
+							}
+						}
+					}
+				},
+				expectedValue : null
 			}
 		];
 		testCases.map(test => {

--- a/tests/mapExpander.js
+++ b/tests/mapExpander.js
@@ -1,7 +1,6 @@
 require('error-object-polyfill');
-const describe = require('mocha').describe
-const it = require('mocha').it
-const expect = require('chai').expect
+const {describe,it} = require('mocha')
+const {expect} = require('chai')
 
 const MapExpander = require('../src/mapExpander');
 


### PR DESCRIPTION
Determine if requested resource is a proxy path by checking if event.resource contains '/{proxy+}'. Pass event.path to getMapValue since it contains any route prefixes for the proxied path

#7 